### PR TITLE
updated allowed_server_type list

### DIFF
--- a/policies/intel-azurerm-linux-virtual-machine-deny-unapproved-instance-type/intel-azurerm-linux-virtual-machine-deny-unapproved-instance-type.sentinel
+++ b/policies/intel-azurerm-linux-virtual-machine-deny-unapproved-instance-type/intel-azurerm-linux-virtual-machine-deny-unapproved-instance-type.sentinel
@@ -57,10 +57,6 @@ header = func(input, output) {
 		output + "\t              Standard_D8_v5, Standard_D16_v5\n",
 		output + "\t              Standard_D32_v5, Standard_D48_v5\n",
 		output + "\t              Standard_D64_v5, Standard_D96_v5\n",
-		output + "\t              Standard_D2s_v5, Standard_D4s_v5\n",
-		output + "\t              Standard_D8s_v5, Standard_D16s_v5\n",
-		output + "\t              Standard_D32s_v5, Standard_D48s_v5\n",
-		output + "\t              Standard_D64s_v5, Standard_D96s_v5\n",
 		output + "\t              Standard_D2d_v5, Standard_D4d_v5\n",
 		output + "\t              Standard_D8d_v5, Standard_D16d_v5\n",
 		output + "\t              Standard_D32d_v5, Standard_D48d_v5\n",
@@ -69,6 +65,7 @@ header = func(input, output) {
 		output + "\t              Standard_D8ds_v5, Standard_D16ds_v5\n",
 		output + "\t              Standard_D32ds_v5, Standard_D48ds_v5\n",
 		output + "\t              Standard_D64ds_v5, Standard_D96ds_v5\n",
+		output + "\t              Standard_D2ds_v5, Standard_D4ds_v5\n",
 		output + "\t              Standard_DC1s_v3, Standard_DC2s_v3\n",
 		output + "\t              Standard_DC4s_v3, Standard_DC8s_v3\n",
 		output + "\t              Standard_DC16s_v3, Standard_DC24s_v3\n",
@@ -83,11 +80,14 @@ header = func(input, output) {
 		output + "\t              Standard_E20_v5, Standard_E32_v5\n",
 		output + "\t              Standard_E48_v5, Standard_E64_v5\n",
 		output + "\t              Standard_E96_v5, Standard_E104i_v5\n",
-		output + "\t              Standard_E2s_v5, Standard_E4s_v5\n",
-		output + "\t              Standard_E8s_v5, Standard_E16s_v5\n",
-		output + "\t              Standard_E20s_v5, Standard_E32s_v5\n",
-		output + "\t              Standard_E48s_v5, Standard_E64s_v5\n",
-		output + "\t              Standard_E96s_v5, Standard_E104is_v5\n",
+		output + "\t              Standard_E2bs_v5, Standard_E4bs_v5\n",
+		output + "\t              Standard_E8bs_v5, Standard_E16bs_v5\n",
+		output + "\t              Standard_E20bs_v5, Standard_E32bs_v5\n",
+		output + "\t              Standard_E48bs_v5, Standard_E64bs_v5\n",
+		output + "\t              Standard_E2bds_v5, Standard_E4bds_v5\n",
+		output + "\t              Standard_E8bds_v5, Standard_E16bds_v5\n",
+		output + "\t              Standard_E32bds_v5, Standard_E48bds_v5\n",
+		output + "\t              Standard_E64bds_v5\n",
 	)
 	return null
 }
@@ -120,7 +120,7 @@ violations = func(input, output) {
 }
 
 // Allowed server resource types
-allowed_server_types = ["Standard_L8s_v3", "Standard_L16s_v3", "Standard_L32s_v3", "Standard_L48s_v3", "Standard_L64s_v3", "Standard_L80s_v3", "Standard_D2_v5", "Standard_D4_v5", "Standard_D8_v5", "Standard_D16_v5", "Standard_D32_v5", "Standard_D48_v5", "Standard_D64_v5", "Standard_D96_v5", "Standard_D2s_v5", "Standard_D4s_v5", "Standard_D8s_v5", "Standard_D16s_v5", "Standard_D32s_v5", "Standard_D48s_v5", "Standard_D64s_v5", "Standard_D96s_v5", "Standard_D2d_v5", "Standard_D4d_v5", "Standard_D8d_v5", "Standard_D16d_v5", "Standard_D32d_v5", "Standard_D48d_v5", "Standard_D64d_v5", "Standard_D96d_v5", "Standard_D2ds_v5", "Standard_D4ds_v5", "Standard_D8ds_v5", "Standard_D16ds_v5", "Standard_D32ds_v5", "Standard_D48ds_v5", "Standard_D64ds_v5", "Standard_D96ds_v5", "Standard_DC1s_v3", "Standard_DC2s_v3", "Standard_DC4s_v3", "Standard_DC8s_v3", "Standard_DC16s_v3", "Standard_DC24s_v3", "Standard_DC32s_v3", "Standard_DC48s_v3", "Standard_DC1ds_v3", "Standard_DC2ds_v3", "Standard_DC4ds_v3", "Standard_DC8ds_v3", "Standard_DC16ds_v3", "Standard_DC24ds_v3", "Standard_DC32ds_v3", "Standard_DC48ds_v3", "Standard_E2_v5", "Standard_E4_v5", "Standard_E8_v5", "Standard_E16_v5", "Standard_E20_v5", "Standard_E32_v5", "Standard_E48_v5", "Standard_E64_v5", "Standard_E96_v5", "Standard_E104i_v5", "Standard_E2s_v5", "Standard_E4s_v5", "Standard_E8s_v5", "Standard_E16s_v5", "Standard_E20s_v5", "Standard_E32s_v5", "Standard_E48s_v5", "Standard_E64s_v5", "Standard_E96s_v5", "Standard_E104is_v5"]
+allowed_server_types = ["Standard_L8s_v3", "Standard_L16s_v3", "Standard_L32s_v3", "Standard_L48s_v3", "Standard_L64s_v3", "Standard_L80s_v3", "Standard_D2_v5", "Standard_D4_v5", "Standard_D8_v5", "Standard_D16_v5", "Standard_D32_v5", "Standard_D48_v5", "Standard_D64_v5", "Standard_D96_v5", "Standard_D2d_v5", "Standard_D4d_v5", "Standard_D8d_v5", "Standard_D16d_v5", "Standard_D32d_v5", "Standard_D48d_v5", "Standard_D64d_v5", "Standard_D96d_v5", "Standard_D2ds_v5", "Standard_D4ds_v5", "Standard_D8ds_v5", "Standard_D16ds_v5", "Standard_D32ds_v5", "Standard_D48ds_v5", "Standard_D64ds_v5", "Standard_D96ds_v5", "Standard_DC1s_v3", "Standard_DC2s_v3", "Standard_DC4s_v3", "Standard_DC8s_v3", "Standard_DC16s_v3", "Standard_DC24s_v3", "Standard_DC32s_v3", "Standard_DC48s_v3", "Standard_DC1ds_v3", "Standard_DC2ds_v3", "Standard_DC4ds_v3", "Standard_DC8ds_v3", "Standard_DC16ds_v3", "Standard_DC24ds_v3", "Standard_DC32ds_v3", "Standard_DC48ds_v3", "Standard_E2_v5", "Standard_E4_v5", "Standard_E8_v5", "Standard_E16_v5", "Standard_E20_v5", "Standard_E32_v5", "Standard_E48_v5", "Standard_E64_v5", "Standard_E96_v5", "Standard_E104i_v5", "Standard_E2bs_v5", "Standard_E4bs_v5", "Standard_E8bs_v5", "Standard_E16bs_v5", "Standard_E32bs_v5", "Standard_E48bs_v5", "Standard_E64bs_v5", "Standard_E2bds_v5", "Standard_E4bds_v5", "Standard_E8bds_v5", "Standard_E16bds_v5", "Standard_E32bds_v5", "Standard_E48bds_v5", "Standard_E64bds_v5"]
 
 doc = {
 	"id":       "linuxvm01",


### PR DESCRIPTION
Updated list to : 

**Storage Optimized:** `Standard_L8s_v3, Standard_L16s_v3, Standard_L32s_v3, Standard_L48s_v3, Standard_L64s_v3, Standard_L80s_v3,`

**General Purpose:** `Standard_D2_v5, Standard_D4_v5, Standard_D8_v5, Standard_D16_v5, Standard_D32_v5, Standard_D48_v5, Standard_D64_v5, Standard_D96_v5, Standard_D2d_v5, Standard_D4d_v5, Standard_D8d_v5, Standard_D16d_v5, Standard_D32d_v5, Standard_D48d_v5, Standard_D64d_v5, Standard_D96d_v5, Standard_D2ds_v5, Standard_D4ds_v5, Standard_D8ds_v5, Standard_D16ds_v5, Standard_D32ds_v5, Standard_D48ds_v5, Standard_D64ds_v5, Standard_D96ds_v5, Standard_DC1s_v3, Standard_DC2s_v3, Standard_DC4s_v3, Standard_DC8s_v3, Standard_DC16s_v3, Standard_DC24s_v3, Standard_DC32s_v3, Standard_DC48s_v3, Standard_DC1ds_v3, Standard_DC2ds_v3, Standard_DC4ds_v3, Standard_DC8ds_v3, Standard_DC16ds_v3, Standard_DC24ds_v3, Standard_DC32ds_v3, Standard_DC48ds_v3`


**Memory Optimized:** `Standard_E2_v5, Standard_E4_v5, Standard_E8_v5, Standard_E16_v5, Standard_E20_v5, Standard_E32_v5, Standard_E48_v5, Standard_E64_v5, Standard_E96_v5, Standard_E104i_v5, Standard_E2bs_v5, Standard_E4bs_v5, Standard_E8bs_v5, Standard_E16bs_v5, Standard_E32bs_v5, Standard_E48bs_v5, Standard_E64bs_v5, Standard_E2bds_v5, Standard_E4bds_v5, Standard_E8bds_v5, Standard_E16bds_v5, Standard_E32bds_v5, Standard_E48bds_v5, Standard_E64bds_v5`