### PR TITLE
3.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/intel/policy-library-intel-azure/blob/main/images/logo-classicblue-800px.png?raw=true" alt="Intel Logo" width="250"/>
 </p>
 
-# Azure Sentinel Policies - Intel Cloud Optimization Modules
+# Azure Sentinel Policies - Intel Optimized Cloud Modules
 
 © Copyright 2022, Intel Corporation
 

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -7,7 +7,7 @@ import "module" "policy_summary" {
   source = "./modules/policysummary.sentinel"
 }
 
-policy "intel-azure-cosmosdb-cassandra-datacenter-deny-unapproved-instance-types" {
+policy "intel-azurerm-cosmosdb-cassandra-datacenter-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-cosmosdb-cassandra-datacenter-deny-unapproved-instance-types/intel-azurerm-cosmosdb-cassandra-datacenter-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
@@ -27,22 +27,22 @@ policy "intel-azurerm-databricks-cluster-enforce-spark-conf" {
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-hdinsight-hadoop-cluster-deny-unapproved-instance-types" {
+policy "intel-azurerm-hdinsight-hadoop-cluster-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-hdinsight-hadoop-cluster/intel-azurerm-hdinsight-hadoop-cluster-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-hdinsight-hbase-cluster-deny-unapproved-instance-types" {
+policy "intel-azurerm-hdinsight-hbase-cluster-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-hdinsight-hbase-cluster/intel-azurerm-hdinsight-hbase-cluster-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-hdinsight-interactive-query-cluster-deny-unapproved-instance-types" {
+policy "intel-azurerm-hdinsight-interactive-query-cluster-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-hdinsight-interactive-query-cluster/intel-azurerm-hdinsight-interactive-query-cluster-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-hdinsight-kafka-cluster-deny-unapproved-instance-types" {
+policy "intel-azurerm-hdinsight-kafka-cluster-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-hdinsight-kafka-cluster/intel-azurerm-hdinsight-kafka-cluster-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
@@ -62,7 +62,7 @@ policy "intel-azurerm-mysql-flexible-server-deny-unapproved-instance-types" {
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-mssql-managed-instance-deny-unapproved-instance-types" {
+policy "intel-azurerm-mssql-managed-instance-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-mssql-managed-instance-deny-unapproved-instance-types/intel-azurerm-mssql-managed-instance-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
@@ -82,12 +82,12 @@ policy "intel-azurerm-service-plan-deny-unapproved-instance-types" {
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-kusto-cluster-deny-unapproved-instance-types" {
+policy "intel-azurerm-kusto-cluster-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-kusto-cluster-deny-unapproved-instance-types/intel-azurerm-kusto-cluster-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }
 
-policy "intel-azure-windows-virtual-machine-deny-unapproved-instance-types" {
+policy "intel-azurerm-windows-virtual-machine-deny-unapproved-instance-types" {
   source = "./policies/intel-azurerm-windows-virtual-machine/intel-azurerm-windows-virtual-machine-deny-unapproved-instance-types.sentinel"
   enforcement_level = "advisory"
 }


### PR DESCRIPTION
Summary of Changes : 

- Rebranded `Intel Cloud Optimization Modules` to `Intel Optimized Cloud Modules` in `README.md`
- Fixed typo in `sentinel.hcl` where policy names contained `$CLOUD` name instead of `$PROVIDER`